### PR TITLE
feat: Enable usage of VersatileImageField

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 FROM python:3.8-alpine
 
-RUN apk update && apk add build-base postgresql-dev
+RUN apk update && apk add build-base postgresql-dev jpeg-dev zlib-dev
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 COPY . /usr/src/app
 
-RUN  pip install -r requirements.txt
+RUN  python -m pip install -U pip && pip install -r requirements.txt
 
 ENTRYPOINT ["sh", "docker-entrypoint.sh"]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,6 +2,10 @@
 Django==2.2.7
 django-environ==0.4.5
 
+# Images
+Pillow==6.2.1
+django-versatileimagefield==2.0
+
 # REST Framework
 djangorestframework==3.9.4
 django-cors-headers==3.2.0

--- a/src/app/settings.py
+++ b/src/app/settings.py
@@ -40,6 +40,7 @@ THIRD_PARTY_APPS = [
     "rest_framework",
     "rest_framework.authtoken",
     "corsheaders",
+    "versatileimagefield",
 ]
 
 PROJECT_APPS = ["users"]

--- a/src/app/settings.py
+++ b/src/app/settings.py
@@ -144,3 +144,74 @@ REST_FRAMEWORK = {
 
 AUTH_USER_MODEL = "users.User"
 
+# VersatileImageField
+
+VERSATILEIMAGEFIELD_SETTINGS = {
+    # The amount of time, in seconds, that references to created images
+    # should be stored in the cache. Defaults to `2592000` (30 days)
+    'cache_length': 2592000,
+    # The name of the cache you'd like `django-versatileimagefield` to use.
+    # Defaults to 'versatileimagefield_cache'. If no cache exists with the name
+    # provided, the 'default' cache will be used instead.
+    'cache_name': 'versatileimagefield_cache',
+    # The save quality of modified JPEG images. More info here:
+    # https://pillow.readthedocs.io/en/latest/handbook/image-file-formats.html#jpeg
+    # Defaults to 70
+    'jpeg_resize_quality': 70,
+    # The name of the top-level folder within storage classes to save all
+    # sized images. Defaults to '__sized__'
+    'sized_directory_name': '__sized__',
+    # The name of the directory to save all filtered images within.
+    # Defaults to '__filtered__':
+    'filtered_directory_name': '__filtered__',
+    # The name of the directory to save placeholder images within.
+    # Defaults to '__placeholder__':
+    'placeholder_directory_name': '__placeholder__',
+    # Whether or not to create new images on-the-fly. Set this to `False` for
+    # speedy performance but don't forget to 'pre-warm' to ensure they're
+    # created and available at the appropriate URL.
+    'create_images_on_demand': True,
+    # A dot-notated python path string to a function that processes sized
+    # image keys. Typically used to md5-ify the 'image key' portion of the
+    # filename, giving each a uniform length.
+    # `django-versatileimagefield` ships with two post processors:
+    # 1. 'versatileimagefield.processors.md5' Returns a full length (32 char)
+    #    md5 hash of `image_key`.
+    # 2. 'versatileimagefield.processors.md5_16' Returns the first 16 chars
+    #    of the 32 character md5 hash of `image_key`.
+    # By default, image_keys are unprocessed. To write your own processor,
+    # just define a function (that can be imported from your project's
+    # python path) that takes a single argument, `image_key` and returns
+    # a string.
+    'image_key_post_processor': None,
+    # Whether to create progressive JPEGs. Read more about progressive JPEGs
+    # here: https://optimus.io/support/progressive-jpeg/
+    'progressive_jpeg': False
+}
+
+# A dictionary used to specify ‘Rendition Key Sets’ that are used for both serialization
+# or as a way to ‘warm’ image files so they don’t need to be created on demand (i.e.
+# when settings.VERSATILEIMAGEFIELD_SETTINGS['create_images_on_demand'] is set to False)
+# which will greatly improve the overall performance of your app. Here’s an example:
+
+VERSATILEIMAGEFIELD_RENDITION_KEY_SETS = {
+    'image_gallery': [
+        ('gallery_large', 'crop__800x450'),
+        ('gallery_square_small', 'crop__50x50')
+    ],
+    'primary_image_detail': [
+        ('hero', 'crop__600x283'),
+        ('social', 'thumbnail__800x800')
+    ],
+    'primary_image_list': [
+        ('list', 'crop__400x225'),
+    ],
+    'headshot': [
+        ('headshot_small', 'crop__150x175'),
+    ]
+}
+
+# Each key in VERSATILEIMAGEFIELD_RENDITION_KEY_SETS signifies a ‘Rendition Key Set’, a
+# list comprised of 2-tuples wherein the first position is a serialization-friendly name
+# of an image rendition and the second position is a ‘Rendition Key’ (which dictates how
+# the original image should be modified).

--- a/src/app/settings.py
+++ b/src/app/settings.py
@@ -156,15 +156,15 @@ if env.bool("ENABLE_SENTRY", False):
 # https://django-versatileimagefield.readthedocs.io/en/latest/installation.html#settings
 
 VERSATILEIMAGEFIELD_SETTINGS = {
-    'cache_length': 2592000,
-    'cache_name': 'versatileimagefield_cache',
-    'jpeg_resize_quality': 70,
-    'sized_directory_name': '__sized__',
-    'filtered_directory_name': '__filtered__',
-    'placeholder_directory_name': '__placeholder__',
-    'create_images_on_demand': True,
-    'image_key_post_processor': None,
-    'progressive_jpeg': False
+    "cache_length": 2592000,
+    "cache_name": "versatileimagefield_cache",
+    "jpeg_resize_quality": 70,
+    "sized_directory_name": "__sized__",
+    "filtered_directory_name": "__filtered__",
+    "placeholder_directory_name": "__placeholder__",
+    "create_images_on_demand": True,
+    "image_key_post_processor": None,
+    "progressive_jpeg": False,
 }
 
 # The rendition key sets will be used if 'create_images_on_demand' is set to False

--- a/src/app/settings.py
+++ b/src/app/settings.py
@@ -145,54 +145,19 @@ REST_FRAMEWORK = {
 AUTH_USER_MODEL = "users.User"
 
 # VersatileImageField
+# https://django-versatileimagefield.readthedocs.io/en/latest/installation.html#settings
 
 VERSATILEIMAGEFIELD_SETTINGS = {
-    # The amount of time, in seconds, that references to created images
-    # should be stored in the cache. Defaults to `2592000` (30 days)
     'cache_length': 2592000,
-    # The name of the cache you'd like `django-versatileimagefield` to use.
-    # Defaults to 'versatileimagefield_cache'. If no cache exists with the name
-    # provided, the 'default' cache will be used instead.
     'cache_name': 'versatileimagefield_cache',
-    # The save quality of modified JPEG images. More info here:
-    # https://pillow.readthedocs.io/en/latest/handbook/image-file-formats.html#jpeg
-    # Defaults to 70
     'jpeg_resize_quality': 70,
-    # The name of the top-level folder within storage classes to save all
-    # sized images. Defaults to '__sized__'
     'sized_directory_name': '__sized__',
-    # The name of the directory to save all filtered images within.
-    # Defaults to '__filtered__':
     'filtered_directory_name': '__filtered__',
-    # The name of the directory to save placeholder images within.
-    # Defaults to '__placeholder__':
     'placeholder_directory_name': '__placeholder__',
-    # Whether or not to create new images on-the-fly. Set this to `False` for
-    # speedy performance but don't forget to 'pre-warm' to ensure they're
-    # created and available at the appropriate URL.
     'create_images_on_demand': True,
-    # A dot-notated python path string to a function that processes sized
-    # image keys. Typically used to md5-ify the 'image key' portion of the
-    # filename, giving each a uniform length.
-    # `django-versatileimagefield` ships with two post processors:
-    # 1. 'versatileimagefield.processors.md5' Returns a full length (32 char)
-    #    md5 hash of `image_key`.
-    # 2. 'versatileimagefield.processors.md5_16' Returns the first 16 chars
-    #    of the 32 character md5 hash of `image_key`.
-    # By default, image_keys are unprocessed. To write your own processor,
-    # just define a function (that can be imported from your project's
-    # python path) that takes a single argument, `image_key` and returns
-    # a string.
     'image_key_post_processor': None,
-    # Whether to create progressive JPEGs. Read more about progressive JPEGs
-    # here: https://optimus.io/support/progressive-jpeg/
     'progressive_jpeg': False
 }
-
-# A dictionary used to specify ‘Rendition Key Sets’ that are used for both serialization
-# or as a way to ‘warm’ image files so they don’t need to be created on demand (i.e.
-# when settings.VERSATILEIMAGEFIELD_SETTINGS['create_images_on_demand'] is set to False)
-# which will greatly improve the overall performance of your app. Here’s an example:
 
 VERSATILEIMAGEFIELD_RENDITION_KEY_SETS = {
     'image_gallery': [
@@ -210,8 +175,3 @@ VERSATILEIMAGEFIELD_RENDITION_KEY_SETS = {
         ('headshot_small', 'crop__150x175'),
     ]
 }
-
-# Each key in VERSATILEIMAGEFIELD_RENDITION_KEY_SETS signifies a ‘Rendition Key Set’, a
-# list comprised of 2-tuples wherein the first position is a serialization-friendly name
-# of an image rendition and the second position is a ‘Rendition Key’ (which dictates how
-# the original image should be modified).

--- a/src/app/settings.py
+++ b/src/app/settings.py
@@ -175,16 +175,5 @@ VERSATILEIMAGEFIELD_SETTINGS = {
 # VERSATILEIMAGEFIELD_RENDITION_KEY_SETS = {
 #     'image_gallery': [
 #         ('gallery_large', 'crop__800x450'),
-#         ('gallery_square_small', 'crop__50x50')
 #     ],
-#     'primary_image_detail': [
-#         ('hero', 'crop__600x283'),
-#         ('social', 'thumbnail__800x800')
-#     ],
-#     'primary_image_list': [
-#         ('list', 'crop__400x225'),
-#     ],
-#     'headshot': [
-#         ('headshot_small', 'crop__150x175'),
-#     ]
 # }

--- a/src/app/settings.py
+++ b/src/app/settings.py
@@ -167,9 +167,10 @@ VERSATILEIMAGEFIELD_SETTINGS = {
     'progressive_jpeg': False
 }
 
-# The rendition key sets are only used if 'create_images_on_demand' is set to False
+# The rendition key sets will be used if 'create_images_on_demand' is set to False
 # It will improve the overall performance of your app by pre warming images
 # These values should come from the app's design specs
+# https://django-versatileimagefield.readthedocs.io/en/latest/installation.html#versatileimagefield-rendition-key-sets
 
 # VERSATILEIMAGEFIELD_RENDITION_KEY_SETS = {
 #     'image_gallery': [

--- a/src/app/settings.py
+++ b/src/app/settings.py
@@ -167,19 +167,23 @@ VERSATILEIMAGEFIELD_SETTINGS = {
     'progressive_jpeg': False
 }
 
-VERSATILEIMAGEFIELD_RENDITION_KEY_SETS = {
-    'image_gallery': [
-        ('gallery_large', 'crop__800x450'),
-        ('gallery_square_small', 'crop__50x50')
-    ],
-    'primary_image_detail': [
-        ('hero', 'crop__600x283'),
-        ('social', 'thumbnail__800x800')
-    ],
-    'primary_image_list': [
-        ('list', 'crop__400x225'),
-    ],
-    'headshot': [
-        ('headshot_small', 'crop__150x175'),
-    ]
-}
+# The rendition key sets are only used if 'create_images_on_demand' is set to False
+# It will improve the overall performance of your app by pre warming images
+# These values should come from the app's design specs
+
+# VERSATILEIMAGEFIELD_RENDITION_KEY_SETS = {
+#     'image_gallery': [
+#         ('gallery_large', 'crop__800x450'),
+#         ('gallery_square_small', 'crop__50x50')
+#     ],
+#     'primary_image_detail': [
+#         ('hero', 'crop__600x283'),
+#         ('social', 'thumbnail__800x800')
+#     ],
+#     'primary_image_list': [
+#         ('list', 'crop__400x225'),
+#     ],
+#     'headshot': [
+#         ('headshot_small', 'crop__150x175'),
+#     ]
+# }

--- a/src/users/migrations/0001_initial.py
+++ b/src/users/migrations/0001_initial.py
@@ -8,9 +8,7 @@ class Migration(migrations.Migration):
 
     initial = True
 
-    dependencies = [
-        ("auth", "0011_update_proxy_permissions"),
-    ]
+    dependencies = [("auth", "0011_update_proxy_permissions")]
 
     operations = [
         migrations.CreateModel(
@@ -89,7 +87,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
             ],
-            options={"abstract": False,},
-            managers=[("objects", users.models.UserManager()),],
-        ),
+            options={"abstract": False},
+            managers=[("objects", users.models.UserManager())],
+        )
     ]


### PR DESCRIPTION
- Adds `jpeg-dev` and `zlib-dev` to `Dockerfile` (needed for `Pillow`)
- Adds `Pillow==6.2.1` and `django-versatileimagefield==2.0` to base requirements
- Adds `"versatileimagefield"` to `THIRD_PARTY_APPS`
- Adds `VERSATILEIMAGEFIELD_SETTINGS` to app's settings
- Adds `VERSATILEIMAGEFIELD_RENDITION_KEY_SETS` comment as a reminder