### PR TITLE
feat: Add Black linter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+-   repo: https://github.com/ambv/black
+    rev: stable
+    hooks:
+    - id: black
+      language_version: python

--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ $ docker-compose up
 
 Check code syntax and style before committing changes.
 
+Pre-commit hook may be installed using the following steps:
+
+```bash
+$ pip install -r requirements/dev.txt
+$ pre-commit install
+```
+
 Or run it manually:
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[tool.black]
+py37 = true
+include = '\.pyi?$'
+exclude = '''
+/(
+    \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | venv
+  | _build
+  | buck-out
+  | build
+  | dist
+  | node_modules
+)/
+'''

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,4 +1,5 @@
 -r base.txt
 
 black==19.10b0
+pre-commit==1.21.0
 docker-compose==1.24.1


### PR DESCRIPTION
- Adds a `pyproject.toml` config file with a `[tool.black]` section.
- Adds `pre-commit` to dev requirements.
- Adds a `.pre-commit-config.yaml` configuration file to run black on a pre-commit hook.

Known issues:
- Pre-commit hook does not respect ignore rules.