### PR TITLE
feat: Add Sentry

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,3 +14,6 @@ whitenoise==4.1.4
 
 # Webserver
 gunicorn==20.0.0
+
+# Sentry
+sentry-sdk==0.13.2

--- a/src/app/local.example.env
+++ b/src/app/local.example.env
@@ -3,3 +3,5 @@ DJANGO_DEBUG=True
 DJANGO_ALLOWED_HOSTS=localhost,
 DATABASE_URL=postgres://postgres:postgres@db:5432/app
 ENV=development
+
+SENTRY_DSN=

--- a/src/app/settings.py
+++ b/src/app/settings.py
@@ -145,7 +145,7 @@ AUTH_USER_MODEL = "users.User"
 
 # Sentry
 
-if not DEBUG:
+if env.bool("ENABLE_SENTRY", False):
     import sentry_sdk
     from sentry_sdk.integrations.django import DjangoIntegration
 

--- a/src/app/settings.py
+++ b/src/app/settings.py
@@ -143,3 +143,10 @@ REST_FRAMEWORK = {
 
 AUTH_USER_MODEL = "users.User"
 
+# Sentry
+
+if not DEBUG:
+    import sentry_sdk
+    from sentry_sdk.integrations.django import DjangoIntegration
+
+    sentry_sdk.init(dsn=env("SENTRY_DSN"), integrations=[DjangoIntegration()])


### PR DESCRIPTION
Using `sentry-sdk` dependency to enable [Sentry](https://sentry.io/) integration.
Requires `SENTRY_DSN` env var to be set.