### PR TITLE
build(deps): Fix docker-compose not installing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.8-alpine
 
-RUN apk update && apk add build-base postgresql-dev
+RUN apk update && apk add build-base postgresql-dev libffi-dev
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -2,4 +2,4 @@
 
 black==19.10b0
 pre-commit==1.21.0
-docker-compose==1.24.1
+docker-compose==1.25.2


### PR DESCRIPTION
`pip install -r requirements/dev.txt` would fail, since `docker-compose` requires `libffi-dev` to be installed.