### PR TITLE
Fix docker caching layer for pip install

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+venv/
+docker/db/*
+**/__pycache__

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ RUN apk update && apk add build-base postgresql-dev
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
-COPY . /usr/src/app
-
+ADD requirements/base.txt ./requirements.txt
 RUN  pip install -r requirements.txt
+COPY . /usr/src/app
 
 ENTRYPOINT ["sh", "docker-entrypoint.sh"]


### PR DESCRIPTION
Force caching of python dependencies for docker images

```bash
...
Step 5/8 : ADD requirements/base.txt ./requirements.txt
 ---> Using cache
 ---> b197860b787d
Step 6/8 : RUN  pip install -r requirements.txt
 ---> Using cache
 ---> d27f85451bcc
...
```