### PR TITLE
Temporary fix for NAT setup (increase in billing)

### DIFF
--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,3 +1,4 @@
 *.tfstate
 .terraform/
 *.tfvars
+*.tfstate.backup

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -83,4 +83,6 @@ module "cluster" {
     hostname = module.database.db_hostname,
     name = module.database.db_name,
   }
+  backend_secret_key = var.backend_secret_key
+  backend_email_from = var.backend_email_from
 }

--- a/terraform/modules/cluster/launch-configuration.tf
+++ b/terraform/modules/cluster/launch-configuration.tf
@@ -36,10 +36,4 @@ resource "aws_launch_configuration" "lc" {
   lifecycle {
     create_before_destroy = true
   }
-
-  root_block_device {
-    volume_type = "standard"
-    volume_size = 40 #The latest ami snapshot needs more than 30GB to create the EC2 instance
-    delete_on_termination = true
-  }
 }

--- a/terraform/modules/cluster/launch-configuration.tf
+++ b/terraform/modules/cluster/launch-configuration.tf
@@ -3,7 +3,7 @@ data "aws_ami" "ecs-optimized" {
 
   filter {
     name = "name"
-    values = ["amzn-ami*amazon-ecs-optimized"]
+    values = ["amzn2-ami-ecs-hvm*"]
   }
 
   filter {
@@ -16,7 +16,7 @@ data "aws_ami" "ecs-optimized" {
     values = ["hvm"]
   }
 
-  owners = ["591542846629"] # AWS
+  owners = ["amazon"] # AWS
 }
 
 resource "aws_launch_configuration" "lc" {

--- a/terraform/modules/network/route-tables.tf
+++ b/terraform/modules/network/route-tables.tf
@@ -38,56 +38,13 @@ resource "aws_route_table_association" "public_subnet_2_rt_a" {
   route_table_id = aws_route_table.rt.id
 }
 
-
-# Allocate an Elastic Ip
-resource "aws_eip" "elastic_ip" {
-  vpc = true
-
-  tags = {
-    Name = "${var.project_name}-${var.environment}-ip"
-    "ckl:environment" = var.environment
-    "ckl:project" = var.project_name
-    "ckl:alias" = "network"
-  }
-}
-
-# Create an Nat gateway with Elatic Ip
-resource "aws_nat_gateway" "nat_gw" {
-  allocation_id = aws_eip.elastic_ip.id
-  subnet_id = aws_subnet.public_subnet.id
-
-  tags = {
-    Name = "${var.project_name}-${var.environment}-nat-gateway"
-    "ckl:environment" = var.environment
-    "ckl:project" = var.project_name
-    "ckl:alias" = "network"
-  }
-}
-
-# Create Route table for private subnets with nat gateway
-resource "aws_route_table" "nat_rt" {
-  vpc_id = aws_vpc.vpc.id
-
-  route {
-    cidr_block = "0.0.0.0/0"
-    nat_gateway_id = aws_nat_gateway.nat_gw.id
-  }
-
-  tags = {
-    Name = "${var.project_name}-${var.environment}-nat-route-table"
-    "ckl:environment" = var.environment
-    "ckl:project" = var.project_name
-    "ckl:alias" = "nat-route-table-with-nat"
-  }
-}
-
 # Associate Route table with public subnets
 resource "aws_route_table_association" "private_subnet_rt_a" {
   subnet_id = aws_subnet.private_subnet.id
-  route_table_id = aws_route_table.nat_rt.id
+  route_table_id = aws_route_table.rt.id
 }
 
 resource "aws_route_table_association" "private_subnet_2_rt_a" {
   subnet_id = aws_subnet.private_subnet_2.id
-  route_table_id = aws_route_table.nat_rt.id
+  route_table_id = aws_route_table.rt.id
 }

--- a/terraform/modules/network/subnets.tf
+++ b/terraform/modules/network/subnets.tf
@@ -3,6 +3,7 @@ resource "aws_subnet" "private_subnet" {
   cidr_block = "10.0.1.0/24"
   vpc_id = aws_vpc.vpc.id
   availability_zone = "${var.region}b"
+  map_public_ip_on_launch = true
 
   tags = {
     Name = "${var.project_name}-${var.environment}-private-subnet"
@@ -16,6 +17,7 @@ resource "aws_subnet" "private_subnet_2" {
   vpc_id = aws_vpc.vpc.id
   cidr_block = "10.0.3.0/24"
   availability_zone = "${var.region}c"
+  map_public_ip_on_launch = true
 
   tags = {
     Name = "${var.project_name}-${var.environment}-private-subnet-2"
@@ -30,6 +32,7 @@ resource "aws_subnet" "public_subnet" {
   vpc_id = aws_vpc.vpc.id
   cidr_block = "10.0.0.0/24"
   availability_zone = "${var.region}b"
+  map_public_ip_on_launch = true
 
   tags = {
     Name = "${var.project_name}-${var.environment}-public-subnet"
@@ -43,6 +46,7 @@ resource "aws_subnet" "public_subnet_2" {
   vpc_id = aws_vpc.vpc.id
   cidr_block = "10.0.2.0/24"
   availability_zone = "${var.region}c"
+  map_public_ip_on_launch = true
 
   tags = {
     Name = "${var.project_name}-${var.environment}--public-subnet-2"


### PR DESCRIPTION
**NOTE: this hasn't been tested with an existing cluster yet**

Our latest ECS cluster configuration adds a private subnet layer that talks to the pubic subnet using a NAT gateway. Since AWS charges NAT gateway by the hour, it impacts in an additional cost of 35~40 dollars per gateway, which is not needed in most cases. This is not a final config, but it's an intermediary step, that can be applied to existing clusters without much impact.