### PR TITLE
build: Add pre-commit to dev requirements

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,4 +1,5 @@
 black==19.10b0
 coverage==4.5.4
+pre-commit==2.0.1
 pytest==5.3.1
 pytest-django==3.7.0


### PR DESCRIPTION
Adding back the requirement after accidental deletion by [this commit](https://github.com/CheesecakeLabs/django-drf-boilerplate/commit/037a8d70298175ba80155a7f216ca8002d155571#diff-ca2f365d2a20e31a4a847b171f063b11L4).