### PR TITLE
Terraform: Improve private/public security groups structure and availability zones

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -24,6 +24,8 @@ module "network" {
   region = var.region
   project_name = var.project_name
   environment = terraform.workspace
+  availability_zone_1 = var.availability_zone_1
+  availability_zone_2 = var.availability_zone_2
 }
 
 module "iam" {
@@ -41,9 +43,10 @@ module "database" {
   project_name = var.project_name
   environment = terraform.workspace
   vpc_id = module.network.vpc_id
-  private_security_group = module.network.private_secutity_group_id
-  private_subnet_id = module.network.private_subnet_id
-  private_subnet_2_id = module.network.private_subnet_2_id
+  security_group = module.network.private_security_group_id
+  subnet_1_id = module.network.private_subnet_1_id
+  subnet_2_id = module.network.private_subnet_2_id
+  availability_zone = var.availability_zone_1
   db_instance_type = var.db_instance_type
   db_storage_size = var.db_storage_size
   db_username = var.db_username
@@ -69,12 +72,14 @@ module "cluster" {
   max_instances = var.cluster_max_instances
   min_instances = var.cluster_min_instances
   desired_instances = var.cluster_desired_instances
-  private_secutity_group_id = module.network.private_secutity_group_id
-  public_secutity_group_id = module.network.public_secutity_group_id
-  private_subnet_id = module.network.private_subnet_id
+  private_security_group_id = module.network.private_security_group_id
+  public_security_group_id = module.network.public_security_group_id
+  private_subnet_1_id = module.network.private_subnet_1_id
   private_subnet_2_id = module.network.private_subnet_2_id
-  public_subnet_id = module.network.public_subnet_id
+  public_subnet_1_id = module.network.public_subnet_1_id
   public_subnet_2_id = module.network.public_subnet_2_id
+  availability_zone_1 = var.availability_zone_1
+  availability_zone_2 = var.availability_zone_2
   domains = var.domains
   app_bucket = module.files.app_bucket.bucket
   database = {

--- a/terraform/modules/cluster/auto-scaling-group.tf
+++ b/terraform/modules/cluster/auto-scaling-group.tf
@@ -4,7 +4,7 @@ resource "aws_autoscaling_group" "asg" {
   min_size = var.min_instances
   desired_capacity = var.desired_instances
   launch_configuration = aws_launch_configuration.lc.name
-  vpc_zone_identifier = [var.private_subnet_id]
+  vpc_zone_identifier = [var.private_subnet_1_id, var.private_subnet_2_id]
   health_check_type = "EC2"
 
   tag {

--- a/terraform/modules/cluster/launch-configuration.tf
+++ b/terraform/modules/cluster/launch-configuration.tf
@@ -23,7 +23,7 @@ resource "aws_launch_configuration" "lc" {
   name_prefix = "${var.project_name}-${var.environment}"
   image_id = data.aws_ami.ecs-optimized.id
   instance_type = var.instance_type
-  security_groups = [var.public_secutity_group_id, var.private_secutity_group_id]
+  security_groups = [var.private_security_group_id]
   iam_instance_profile = var.ecs_instance_profile_id
   user_data = <<EOF
       #!/bin/bash

--- a/terraform/modules/cluster/load-balancer.tf
+++ b/terraform/modules/cluster/load-balancer.tf
@@ -2,8 +2,8 @@ resource "aws_lb" "lb" {
   name = "${var.project_name}-${var.environment}"
   internal = false
   load_balancer_type = "application"
-  security_groups = [var.public_secutity_group_id]
-  subnets = [var.public_subnet_id, var.public_subnet_2_id]
+  security_groups = [var.public_security_group_id]
+  subnets = [var.public_subnet_1_id, var.public_subnet_2_id]
 
   tags = {
     Name = "${var.project_name}-${var.environment}"

--- a/terraform/modules/cluster/service/main.tf
+++ b/terraform/modules/cluster/service/main.tf
@@ -24,6 +24,8 @@ resource "aws_ecs_service" "service" {
   }
 
   depends_on = [
+    var.lb_listener_http,
+    var.lb_listener_https,
     aws_lb_target_group.tg,
   ]
 }

--- a/terraform/modules/cluster/variables.tf
+++ b/terraform/modules/cluster/variables.tf
@@ -1,11 +1,13 @@
 variable "environment" {}
 variable "project_name" {}
 variable "region" {}
-variable "private_secutity_group_id" {}
-variable "public_secutity_group_id" {}
-variable "private_subnet_id" {}
+variable "availability_zone_1" {}
+variable "availability_zone_2" {}
+variable "private_security_group_id" {}
+variable "public_security_group_id" {}
+variable "private_subnet_1_id" {}
 variable "private_subnet_2_id" {}
-variable "public_subnet_id" {}
+variable "public_subnet_1_id" {}
 variable "public_subnet_2_id" {}
 variable "vpc_id" {}
 variable "ecs_instance_role" {}

--- a/terraform/modules/database/main.tf
+++ b/terraform/modules/database/main.tf
@@ -1,14 +1,14 @@
 resource "aws_db_subnet_group" "db_subnet" {
   name = "${var.project_name}-${var.environment}-db-subnet"
-  subnet_ids = [var.private_subnet_id, var.private_subnet_2_id]
+  subnet_ids = [var.subnet_1_id, var.subnet_2_id]
 }
 
 resource "aws_db_instance" "app_db" {
   instance_class = var.db_instance_type
   name = replace("${var.project_name}_${var.environment}", "-", "_")
   engine = "postgres"
-  availability_zone = "${var.region}b"
-  vpc_security_group_ids = [var.private_security_group]
+  availability_zone = "${var.region}${var.availability_zone}"
+  vpc_security_group_ids = [var.security_group]
   allocated_storage = var.db_storage_size
   password = var.db_password
   username = var.db_username

--- a/terraform/modules/database/variables.tf
+++ b/terraform/modules/database/variables.tf
@@ -4,8 +4,9 @@ variable "environment" {}
 variable "vpc_id" {}
 variable "db_storage_size" {}
 variable "db_instance_type" {}
-variable "private_security_group" {}
-variable "private_subnet_id" {}
-variable "private_subnet_2_id" {}
+variable "security_group" {}
+variable "subnet_1_id" {}
+variable "subnet_2_id" {}
+variable "availability_zone" {}
 variable "db_username" {}
 variable "db_password" {}

--- a/terraform/modules/network/outputs.tf
+++ b/terraform/modules/network/outputs.tf
@@ -2,26 +2,26 @@ output "vpc_id" {
   value = aws_vpc.vpc.id
 }
 
-output "private_subnet_id" {
-  value = aws_subnet.private_subnet.id
+output "private_subnet_1_id" {
+  value = aws_subnet.private_subnet_1.id
 }
 
 output "private_subnet_2_id" {
   value = aws_subnet.private_subnet_2.id
 }
 
-output "public_subnet_id" {
-  value = aws_subnet.public_subnet.id
+output "public_subnet_1_id" {
+  value = aws_subnet.public_subnet_1.id
 }
 
 output "public_subnet_2_id" {
   value = aws_subnet.public_subnet_2.id
 }
 
-output "public_secutity_group_id" {
-  value = aws_security_group.public_secutity_group.id
+output "public_security_group_id" {
+  value = aws_security_group.public_security_group.id
 }
 
-output "private_secutity_group_id" {
-  value = aws_security_group.private_secutity_group.id
+output "private_security_group_id" {
+  value = aws_security_group.private_security_group.id
 }

--- a/terraform/modules/network/route-tables.tf
+++ b/terraform/modules/network/route-tables.tf
@@ -10,7 +10,7 @@ resource "aws_internet_gateway" "igw" {
   }
 }
 
-# Create Route table for public subnets with internet gateway
+# Create Route table for subnets with internet gateway
 resource "aws_route_table" "rt" {
   vpc_id = aws_vpc.vpc.id
 
@@ -28,8 +28,8 @@ resource "aws_route_table" "rt" {
 }
 
 # Associate Route table with public subnets
-resource "aws_route_table_association" "public_subnet_rt_a" {
-  subnet_id = aws_subnet.public_subnet.id
+resource "aws_route_table_association" "public_subnet_1_rt_a" {
+  subnet_id = aws_subnet.public_subnet_1.id
   route_table_id = aws_route_table.rt.id
 }
 
@@ -38,9 +38,9 @@ resource "aws_route_table_association" "public_subnet_2_rt_a" {
   route_table_id = aws_route_table.rt.id
 }
 
-# Associate Route table with public subnets
+# Associate Route table with private subnets
 resource "aws_route_table_association" "private_subnet_rt_a" {
-  subnet_id = aws_subnet.private_subnet.id
+  subnet_id = aws_subnet.private_subnet_1.id
   route_table_id = aws_route_table.rt.id
 }
 

--- a/terraform/modules/network/security-groups.tf
+++ b/terraform/modules/network/security-groups.tf
@@ -1,4 +1,4 @@
-resource "aws_security_group" "public_secutity_group" {
+resource "aws_security_group" "public_security_group" {
   name = "${var.project_name}-${var.environment}-public"
   description = "Public access from HTTP and HTTPS"
   vpc_id = aws_vpc.vpc.id
@@ -31,7 +31,7 @@ resource "aws_security_group" "public_secutity_group" {
   }
 }
 
-resource "aws_security_group" "private_secutity_group" {
+resource "aws_security_group" "private_security_group" {
   name = "${var.project_name}-${var.environment}-private"
   description = "Private access allowed from public security group"
   vpc_id = aws_vpc.vpc.id
@@ -41,16 +41,8 @@ resource "aws_security_group" "private_secutity_group" {
     to_port = 0
     protocol = "-1"
     security_groups = [
-      aws_security_group.public_secutity_group.id
+      aws_security_group.public_security_group.id
     ]
-  }
-
-  ingress {
-    from_port = 0
-    to_port = 0
-    protocol = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-    self = true
   }
 
   egress {

--- a/terraform/modules/network/subnets.tf
+++ b/terraform/modules/network/subnets.tf
@@ -1,8 +1,8 @@
-## Private Subnets
-resource "aws_subnet" "private_subnet" {
+# Private Subnets
+resource "aws_subnet" "private_subnet_1" {
   cidr_block = "10.0.1.0/24"
   vpc_id = aws_vpc.vpc.id
-  availability_zone = "${var.region}b"
+  availability_zone = "${var.region}${var.availability_zone_1}"
   map_public_ip_on_launch = true
 
   tags = {
@@ -16,7 +16,7 @@ resource "aws_subnet" "private_subnet" {
 resource "aws_subnet" "private_subnet_2" {
   vpc_id = aws_vpc.vpc.id
   cidr_block = "10.0.3.0/24"
-  availability_zone = "${var.region}c"
+  availability_zone = "${var.region}${var.availability_zone_2}"
   map_public_ip_on_launch = true
 
   tags = {
@@ -28,10 +28,10 @@ resource "aws_subnet" "private_subnet_2" {
 }
 
 # Public Subnets
-resource "aws_subnet" "public_subnet" {
+resource "aws_subnet" "public_subnet_1" {
   vpc_id = aws_vpc.vpc.id
   cidr_block = "10.0.0.0/24"
-  availability_zone = "${var.region}b"
+  availability_zone = "${var.region}${var.availability_zone_1}"
   map_public_ip_on_launch = true
 
   tags = {
@@ -45,7 +45,7 @@ resource "aws_subnet" "public_subnet" {
 resource "aws_subnet" "public_subnet_2" {
   vpc_id = aws_vpc.vpc.id
   cidr_block = "10.0.2.0/24"
-  availability_zone = "${var.region}c"
+  availability_zone = "${var.region}${var.availability_zone_2}"
   map_public_ip_on_launch = true
 
   tags = {

--- a/terraform/modules/network/variables.tf
+++ b/terraform/modules/network/variables.tf
@@ -1,3 +1,5 @@
 variable "environment" {}
 variable "project_name" {}
 variable "region" {}
+variable "availability_zone_1" {}
+variable "availability_zone_2" {}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -7,6 +7,12 @@ variable "aws_profile" {
 variable "project_name" {
   description = "Our project name"
 }
+variable "availability_zone_1" {
+  default = "a"
+}
+variable "availability_zone_2" {
+  default = "b"
+}
 variable "cluster_instance_type" {
   description = "The type of EC2 instance used on the cluster. ex: (t2.micro, t2.small...)"
   default = "t3.micro"


### PR DESCRIPTION
This PR moves the availability zones definition to tfvars, since they can change depending on the chosen region. It also reviews the way private/public security groups structure: renaming subnets, removing a "public" ingress rule.

NOTE: the use of separate private/public subnets is not needed anymore, but this way we have a better flexibility of simply adding a NAT gateway in case we want to isolate a part of the system in a internal network.