### PR TITLE
build(deps): Bump Django from 2.2.8 to 2.2.10

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 # Django
-Django==2.2.8
+Django==2.2.10
 django-environ==0.4.5
 
 # REST Framework


### PR DESCRIPTION
While the discussion regarding Django 3.x.x goes on (#76), shouldn't we bump the minor version to patch those pesky security vulnerabilities?

- [2.2.9 security patch](https://docs.djangoproject.com/en/2.2/releases/2.2.9/)
- [2.2.10 security patch](https://docs.djangoproject.com/en/2.2/releases/2.2.10/)