### PR TITLE
fix: Terraform Environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,12 +61,22 @@ web:
 ```
 
 don't forget to define these environment variables in your circleci project settings:
-- AWS_DEFAULT_REGION
-- AWS_ACCOUNT_ID
-- AWS_RESOURCE_NAME_PREFIX
-- AWS_SERVICE_NAME_LAB
-- AWS_SERVICE_NAME_STAGING
-- AWS_SERVICE_NAME_PROD
+- `AWS_ACCOUNT_ID`
+- `AWS_ACCESS_KEY_ID`
+- `AWS_SECRET_ACCESS_KEY`
+- `AWS_DEFAULT_REGION` (ex: `us-east-1`)
+- `AWS_RESOURCE_NAME_PREFIX` (ex: `${project_name}-backend`)
+- `AWS_SERVICE_NAME_LAB` (ex: `${project_name}-backend-lab`)
+- `AWS_SERVICE_NAME_STAGING` (ex: `${project_name}-backend-staging`)
+- `AWS_SERVICE_NAME_PROD` (ex: `${project_name}-backend-production`)
+- `AWS_CLUSTER_NAME_LAB` (ex: `${project_name}-lab`)
+- `AWS_CLUSTER_NAME_STAGING` (ex: `${project_name}-staging`)
+- `AWS_CLUSTER_NAME_PROD` (ex: `${project_name}-production`)
+- `CC_TEST_REPORTER_ID` ([from CodeClimate](https://docs.codeclimate.com/docs/finding-your-test-coverage-token))
+- `ENVIRONMENT` (ex: `development`)
+- `DJANGO_DEBUG` (ex: `True`)
+- `DJANGO_ALLOWED_HOSTS` (ex: `*,`)
+- `DJANGO_SECRET_KEY`
 
 
 ## Database

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -4,21 +4,25 @@ set -e
 set -u
 
 SERVICE_NAME=""
+AWS_CLUSTER_NAME=""
 TAG=""
 case $1 in
     "lab")
         echo "deploying to LAB"
         SERVICE_NAME=${AWS_SERVICE_NAME_LAB}
+        AWS_CLUSTER_NAME=${AWS_CLUSTER_NAME_LAB}
         TAG="lab"
     ;;
     "staging")
         echo "deploying to STAGING"
         SERVICE_NAME=${AWS_SERVICE_NAME_STAGING}
+        AWS_CLUSTER_NAME=${AWS_CLUSTER_NAME_STAGING}
         TAG="staging"
     ;;
     *)
         echo "deploying to PRODUCTION"
         SERVICE_NAME=${AWS_SERVICE_NAME_PROD}
+        AWS_CLUSTER_NAME=${AWS_CLUSTER_NAME_PROD}
         TAG=${CIRCLE_TAG}
         docker tag ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${AWS_RESOURCE_NAME_PREFIX}:latest ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${AWS_RESOURCE_NAME_PREFIX}:${CIRCLE_TAG}
         docker push ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${AWS_RESOURCE_NAME_PREFIX}:${CIRCLE_TAG}

--- a/terraform/modules/iam/deploy.tf
+++ b/terraform/modules/iam/deploy.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_user" "deploy-user" {
-  name = "${var.project_name}_deploy_user"
+  name = "${var.project_name}_deploy_user_${var.environment}"
   tags = {
     "ckl:project" = var.project_name
     "ckl:alias" = "app"
@@ -12,7 +12,7 @@ resource "aws_iam_user_policy_attachment" "policy-attachment" {
 }
 
 resource "aws_iam_policy" "deploy-policy" {
-  name = "${var.project_name}_deploy_policy"
+  name = "${var.project_name}_deploy_policy_${var.environment}"
   policy = data.aws_iam_policy_document.ecs-deploy-policy.json
 }
 

--- a/terraform/modules/iam/roles.tf
+++ b/terraform/modules/iam/roles.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role" "ecs-service-role" {
-  name = "${var.project_name}-ECS-Service-Role"
+  name = "${var.project_name}-ECS-Service-Role-${var.environment}"
   assume_role_policy = data.aws_iam_policy_document.ecs-service-policy.json
   tags = {
     "ckl:project" = var.project_name


### PR DESCRIPTION
- `scripts/deploy.sh` now has a specific `AWS_CLUSTER_NAME` for each environment
- The following resources no longer have the same name on all environments:
  - `"aws_iam_user" "deploy-user"`
  - `"aws_iam_policy" "deploy-policy"`
  - `"aws_iam_role" "ecs-service-role"`