### PR TITLE
refactor: Change Dockerfile base image to python:3.8-slim-buster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM python:3.8-alpine
+FROM python:3.8-slim-buster
 
-RUN apk update && apk add build-base postgresql-dev jpeg-dev zlib-dev
+RUN apt-get update && apt-get install --yes libmagic-dev
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app


### PR DESCRIPTION
As discussed briefly on #83, there are some advantages in changing the base image to `slim-buster` instead of `alpine`.