### PR TITLE
fix(terraform): Add key-pair to launch configuration

### DIFF
--- a/terraform/modules/cluster/launch-configuration.tf
+++ b/terraform/modules/cluster/launch-configuration.tf
@@ -36,6 +36,7 @@ resource "aws_launch_configuration" "lc" {
   instance_type = var.instance_type
   security_groups = [var.private_security_group_id]
   iam_instance_profile = var.ecs_instance_profile_id
+  key_name = aws_key_pair.ssh_access.key_name
   user_data = <<EOF
       #!/bin/bash
       echo ECS_CLUSTER=${aws_ecs_cluster.cluster.name} >> /etc/ecs/ecs.config


### PR DESCRIPTION
We're adding the public key to the launch configuration, in order to enable ssh access.

We might also want to add:
```
lifecycle {
  ignore_changes = ["public_key"]
}
```
So that subsequent `terraform apply`s don't alter the ssh keys.