### PR TITLE
feat: Health Check endpoint

### DIFF
--- a/src/app/urls.py
+++ b/src/app/urls.py
@@ -1,9 +1,11 @@
 from django.contrib import admin
 from django.urls import include, path
 
+from helpers.health_check import health_check
 
 urlpatterns = [
     path("admin/", admin.site.urls),
     # Enables the DRF browsable API page
     path("api-auth/", include("rest_framework.urls", namespace="rest_framework")),
+    path("health_check/", health_check, name="health_check"),
 ]

--- a/src/helpers/health_check.py
+++ b/src/helpers/health_check.py
@@ -1,0 +1,12 @@
+from django.views.decorators.csrf import csrf_exempt
+from rest_framework import status
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+
+
+@csrf_exempt
+@api_view(("GET",))
+@permission_classes((AllowAny,))
+def health_check(_request):
+    return Response(status=status.HTTP_200_OK)

--- a/terraform/modules/cluster/main.tf
+++ b/terraform/modules/cluster/main.tf
@@ -27,7 +27,7 @@ module "backend" {
   lb_listener_http = aws_lb_listener.http_listener
   lb_listener_https = aws_lb_listener.https_listener
   task_definition_file = "${path.module}/task-definitions/backend.json"
-  health_check_path = "/admin/login/?next=/admin/"
+  health_check_path = "/health_check/"
   # TODO: replace placeholder vars
   container_env_vars = {
     environment: var.environment,


### PR DESCRIPTION
Shouldn't we use a simple/fast endpoint for health checks?
Using `/admin/login/?next=/admin/` will load all kinds of stuff, wasting resources and increasing CI's total running time.
This PR implements a simple `/health_check/` endpoint that returns `200` immediately.