### PR TITLE
Feat: Add an option to force redirect to https

### DIFF
--- a/terraform/modules/cluster/service/target-group.tf
+++ b/terraform/modules/cluster/service/target-group.tf
@@ -16,6 +16,7 @@ resource "aws_lb_target_group" "tg" {
 }
 
 resource "aws_lb_listener_rule" "host_based_routing_http" {
+  count = var.force_https_redirect ? 0 : 1
   listener_arn = var.lb_listener_http.arn
 
   action {
@@ -25,7 +26,27 @@ resource "aws_lb_listener_rule" "host_based_routing_http" {
 
   condition {
     field = "host-header"
-    values = ["${var.domain}"]
+    values = [var.domain]
+  }
+}
+
+resource "aws_lb_listener_rule" "https_force_redirect" {
+  count = var.force_https_redirect ? 1 : 0
+  listener_arn = var.lb_listener_http.arn
+
+  action {
+    type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_302"
+    }
+  }
+
+  condition {
+    field = "host-header"
+    values = [var.domain]
   }
 }
 
@@ -39,6 +60,6 @@ resource "aws_lb_listener_rule" "host_based_routing_https" {
 
   condition {
     field = "host-header"
-    values = ["${var.domain}"]
+    values = [var.domain]
   }
 }

--- a/terraform/modules/cluster/service/target-group.tf
+++ b/terraform/modules/cluster/service/target-group.tf
@@ -40,7 +40,7 @@ resource "aws_lb_listener_rule" "https_force_redirect" {
     redirect {
       port        = "443"
       protocol    = "HTTPS"
-      status_code = "HTTP_302"
+      status_code = "HTTP_301"
     }
   }
 

--- a/terraform/modules/cluster/service/variables.tf
+++ b/terraform/modules/cluster/service/variables.tf
@@ -17,3 +17,8 @@ variable "health_check_path" {
   default = "/"
 }
 variable "container_env_vars" {}
+variable "force_https_redirect" {
+  description = "This options will force the loadbalancer to redirect to HTTPS"
+  type = bool
+  default = false
+}


### PR DESCRIPTION
### Description
- This PR add a option to force the LoadBalancer redirect to HTTPS. So if the client hit the host using http, the LoadBalancer will automatically redirect to https with the same hostname.

### Usage
- Just pass the variable `force_https_redirect` in service module declaration.
`module "frontend" {
  source = "./service"
  ....
  force_https_redirect = true
}`

### Considerations
 - If enabled, the service will not be able to be hitted using http.
 - The status code returned is [301](https://http.cat/301)