### PR TITLE
fix: Update release and deploy scripts to match terraform struct

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,33 +1,36 @@
-  
 #!/bin/bash
 set -e
 set -u
 
 SERVICE_NAME=""
 AWS_CLUSTER_NAME=""
+AWS_RESOURCE_NAME=""
 TAG=""
 case $1 in
     "lab")
         echo "deploying to LAB"
         SERVICE_NAME=${AWS_SERVICE_NAME_LAB}
         AWS_CLUSTER_NAME=${AWS_CLUSTER_NAME_LAB}
-        TAG="lab"
+        AWS_RESOURCE_NAME="${AWS_RESOURCE_NAME_PREFIX}/lab"
+        TAG="latest"
     ;;
     "staging")
         echo "deploying to STAGING"
         SERVICE_NAME=${AWS_SERVICE_NAME_STAGING}
         AWS_CLUSTER_NAME=${AWS_CLUSTER_NAME_STAGING}
-        TAG="staging"
+        AWS_RESOURCE_NAME="${AWS_RESOURCE_NAME_PREFIX}/staging"
+        TAG="latest"
     ;;
     *)
         echo "deploying to PRODUCTION"
         SERVICE_NAME=${AWS_SERVICE_NAME_PROD}
         AWS_CLUSTER_NAME=${AWS_CLUSTER_NAME_PROD}
+        AWS_RESOURCE_NAME="${AWS_RESOURCE_NAME_PREFIX}/production"
         TAG=${CIRCLE_TAG}
-        docker tag ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${AWS_RESOURCE_NAME_PREFIX}:latest ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${AWS_RESOURCE_NAME_PREFIX}:${CIRCLE_TAG}
-        docker push ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${AWS_RESOURCE_NAME_PREFIX}:${CIRCLE_TAG}
+        docker tag ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${AWS_RESOURCE_NAME}:latest ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${AWS_RESOURCE_NAME}:${CIRCLE_TAG}
+        docker push ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${AWS_RESOURCE_NAME}:${CIRCLE_TAG}
     ;;
 esac
 
 # deploying to AWS ECS
-ecs-deploy -c ${AWS_CLUSTER_NAME} -n ${SERVICE_NAME} -i ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${AWS_RESOURCE_NAME_PREFIX}:${TAG} -r ${AWS_DEFAULT_REGION} --timeout 108000
+ecs-deploy -c ${AWS_CLUSTER_NAME} -n ${SERVICE_NAME} -i ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${AWS_RESOURCE_NAME}:${TAG} -r ${AWS_DEFAULT_REGION} --timeout 108000

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,24 +1,24 @@
-  
 #!/bin/bash
 set -e
 set -u
 
-TAG=""
+AWS_RESOURCE_NAME=""
 case $1 in
     "master")
-        TAG="latest"
+        AWS_RESOURCE_NAME="${AWS_RESOURCE_NAME_PREFIX}/production"
     ;;
     "staging")
-        TAG="staging"
+        AWS_RESOURCE_NAME="${AWS_RESOURCE_NAME_PREFIX}/staging"
     ;;
     "lab")
-        TAG="lab"
+        AWS_RESOURCE_NAME="${AWS_RESOURCE_NAME_PREFIX}/lab"
     ;;
     *)
         echo "branch not defined"
         exit 1
     ;;
 esac
+
 echo "release ${CIRCLE_BRANCH}"
-docker tag ${IMAGE_NAME}:latest ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${AWS_RESOURCE_NAME_PREFIX}:${TAG}
-docker push ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${AWS_RESOURCE_NAME_PREFIX}:${TAG}
+docker tag ${IMAGE_NAME}:latest ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${AWS_RESOURCE_NAME}:latest
+docker push ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${AWS_RESOURCE_NAME}:latest


### PR DESCRIPTION
- `release.sh` script will always create a `latest` ECR release of image corresponding to environment
- `deploy.sh` will deploy the correct ECR image (and also create tag release on prod env)