### PR TITLE
fix: CORS config

### DIFF
--- a/src/app/local.example.env
+++ b/src/app/local.example.env
@@ -1,6 +1,8 @@
 DJANGO_SECRET_KEY=fr5r80uji*^IPcd809_OUCT&D&80pi
 DJANGO_DEBUG=True
 DJANGO_ALLOWED_HOSTS=localhost,
+CORS_ORIGIN_ALLOW_ALL=True
+CORS_ORIGIN_WHITELIST=
 DATABASE_URL=postgres://postgres:postgres@db:5432/app
 ENV=development
 INTERNAL_IPS=localhost,

--- a/src/app/settings.py
+++ b/src/app/settings.py
@@ -25,6 +25,13 @@ DEBUG = env.bool("DJANGO_DEBUG", False)
 ENVIRONMENT = env("ENV")
 ALLOWED_HOSTS = env.list("DJANGO_ALLOWED_HOSTS", default=[])
 
+# CORS
+CORS_ORIGIN_ALLOW_ALL = env.bool("CORS_ORIGIN_ALLOW_ALL", default=False)
+if not CORS_ORIGIN_ALLOW_ALL:
+    CORS_ORIGIN_WHITELIST = env.str(
+        "CORS_ORIGIN_WHITELIST", default="localhost,127.0.0.1"
+    ).split(",")
+
 # Application definition
 DJANGO_APPS = [
     "django.contrib.admin",


### PR DESCRIPTION
## Description:

Adds these parameters to `settings.py`:

- `CORS_ORIGIN_ALLOW_ALL`: default = `False`
- `CORS_ORIGIN_WHITELIST`: default = `localhost,127.0.0.1`
  - Not set if `CORS_ORIGIN_ALLOW_ALL` is `True`