### PR TITLE
fix: update deploy job on tagged build

### DIFF
--- a/{{ cookiecutter.project_slug }}/.circleci/config.yml
+++ b/{{ cookiecutter.project_slug }}/.circleci/config.yml
@@ -88,6 +88,7 @@ jobs:
       - image: circleci/python:3.8.0b1-stretch
     steps:
       - checkout
+      - setup_remote_docker
       - run:
           name: Installing awscli
           command: |

--- a/{{ cookiecutter.project_slug }}/scripts/deploy.sh
+++ b/{{ cookiecutter.project_slug }}/scripts/deploy.sh
@@ -27,6 +27,7 @@ case $1 in
         AWS_CLUSTER_NAME=${AWS_CLUSTER_NAME_PROD}
         AWS_RESOURCE_NAME="${AWS_RESOURCE_NAME_PREFIX}/production"
         TAG=${CIRCLE_TAG}
+        docker pull ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${AWS_RESOURCE_NAME}:latest
         docker tag ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${AWS_RESOURCE_NAME}:latest ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${AWS_RESOURCE_NAME}:${CIRCLE_TAG}
         docker push ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${AWS_RESOURCE_NAME}:${CIRCLE_TAG}
     ;;

--- a/{{ cookiecutter.project_slug }}/scripts/deploy.sh
+++ b/{{ cookiecutter.project_slug }}/scripts/deploy.sh
@@ -6,6 +6,14 @@ SERVICE_NAME=""
 AWS_CLUSTER_NAME=""
 AWS_RESOURCE_NAME=""
 TAG=""
+
+# validate if $1 variable exists if not, it means it is a tagged build, without circle branch variable
+# (+x) parameter expansion
+if [ -z ${1+x} ]
+then
+    set -- "production"
+fi
+
 case $1 in
     "lab")
         echo "deploying to LAB"


### PR DESCRIPTION
fix a bug related to the deploy job for tagged build pipelines.
implementation:
- setup docker remote to the job
- update the lastest image to target tag 

same but was faced by engineeringstats team