### PR TITLE
Fix: Resolve deploy dependency conflict

### DIFF
--- a/{{ cookiecutter.project_slug }}/.circleci/config.yml
+++ b/{{ cookiecutter.project_slug }}/.circleci/config.yml
@@ -92,7 +92,7 @@ jobs:
           name: Installing awscli
           command: |
             sudo apt-get install jq
-            sudo pip install --upgrade setuptools awscli awsebcli
+            sudo pip install --upgrade setuptools awscli awsebcli --use-feature=2020-resolver
             curl https://raw.githubusercontent.com/silinternational/ecs-deploy/master/ecs-deploy | sudo tee /usr/bin/ecs-deploy
             sudo chmod +x /usr/bin/ecs-deploy
       - run: eval $(aws ecr get-login --region ${AWS_DEFAULT_REGION} | sed 's|https://||' | sed 's|-e none ||')


### PR DESCRIPTION
## Description:

We're facing a problem to deploy our releases to lab and staging due to a dependency conflict which is causing the deploy script on CircleCI to install a version of urlllib that does not works with botocore.

```
ERROR: After October 2020 you may experience errors when installing or updating packages. This is because pip will change the way that it resolves dependency conflicts.

We recommend you use --use-feature=2020-resolver to test your packages with the new resolver before it becomes the default.

requests 2.20.1 requires urllib3<1.25,>=1.21.1, but you'll have urllib3 1.25.11 which is incompatible.
awsebcli 3.19.1 requires botocore<1.18,>=1.17, but you'll have botocore 1.19.0 which is incompatible.
awsebcli 3.19.1 requires urllib3<1.25,>=1.24.1, but you'll have urllib3 1.25.11 which is incompatible.
```

The addition of `--use-feature-2020-resolver` on pip install fixes that by using the latest feature that they have been developing.

Another solution would need to consider pinning each one of the dependency versions that satisfy each one of the dependencies.